### PR TITLE
Replacing RGB with RBG for DDS pixel header flags

### DIFF
--- a/bethesda_structs/archive/btdx.py
+++ b/bethesda_structs/archive/btdx.py
@@ -303,10 +303,10 @@ class BTDXArchive(BaseArchive):
                 dict(
                     dwFlags=dict(DDPF_ALPHA=True, DDPF_RBG=True),
                     dwRGBBitCount=32,
-                    dwABitMask=0xff000000,
-                    dwRBitMask=0x00ff0000,
-                    dwGBitMask=0x0000ff00,
-                    dwBBitMask=0x000000ff,
+                    dwABitMask=0xFF000000,
+                    dwRBitMask=0x00FF0000,
+                    dwGBitMask=0x0000FF00,
+                    dwBBitMask=0x000000FF,
                 )
             )
             header_data.update(
@@ -319,7 +319,7 @@ class BTDXArchive(BaseArchive):
         elif file_container.header.format == DXGIFormats.DXGI_FORMAT_R8_UNORM:
             pixel_data.update(
                 dict(
-                    dwFlags=dict(DDPF_RGB=True), dwRGBBitCount=8, dwRBitMask=0x000000ff
+                    dwFlags=dict(DDPF_RGB=True), dwRGBBitCount=8, dwRBitMask=0x000000FF
                 )
             )
             header_data.update(

--- a/bethesda_structs/contrib/dds.py
+++ b/bethesda_structs/contrib/dds.py
@@ -150,7 +150,7 @@ class DXGIFormats(IntEnum):
     DXGI_FORMAT_P208 = 130
     DXGI_FORMAT_V208 = 131
     DXGI_FORMAT_V408 = 132
-    DXGI_FORMAT_FORCE_UINT = 0xffffffff
+    DXGI_FORMAT_FORCE_UINT = 0xFFFFFFFF
 
 
 class D3D10ResourceDimension(IntEnum):
@@ -205,7 +205,7 @@ DDS_PIXELFORMAT = Struct(
             DDPF_ALPHAPIXELS=0x00000001,
             DDPF_ALPHA=0x00000002,
             DDPF_FOURCC=0x00000004,
-            DDPF_RGB=0x00000040,
+            DDPF_RBG=0x00000040,
             DDPF_YUV=0x00000200,
             DDPF_LUMINANCE=0x00020000,
         ),


### PR DESCRIPTION
### Pull Request Checklist
🚨 Please review the [contributing guidelines](../CONTRIBUTING.rst) to this repository.

- [x] Make sure that you are requesting to pull a **topic/feature/bugfix** branch (left side). _Don't request your master!_
- [x] Check that your code additions will not fail our requested style guidelines or linting checks.

### Description
Unexpectedly, `dwFlags` for DDPF actually names their fields RGB instead of RBG. This was encountered in issue #13. This _should_ fix the immediate issue ❤️ 	

---

❤️ Thank you!
